### PR TITLE
Subheadings added (New PR)

### DIFF
--- a/src/components/ambassador/Ambassador.js
+++ b/src/components/ambassador/Ambassador.js
@@ -18,6 +18,8 @@ const Content = () => {
           <div className="header-details">
             <h1>Ambassador</h1>
 
+            <p>Place where you can find all the resources and details of ambassador/fellowship that are available across different countries and companies.</p>
+
             <Link to="container" smooth={true} duration={1000}>
               <h4>Explore all</h4>
             </Link>

--- a/src/components/js-toolkits/JSToolkits.js
+++ b/src/components/js-toolkits/JSToolkits.js
@@ -17,6 +17,8 @@ const Content = () => {
         <div className="landing-page-header">
           <div className="header-details">
             <h1>JS Toolkits</h1>
+            
+            <p>While the number of ways to organize JavaScript is almost infinite, here are some collection of JS framework and libraries that can help you while you are working on a project or searching around the web.</p>
 
             <Link to="container" smooth={true} duration={1000}>
               <h4>Explore all</h4>

--- a/src/components/programs/Programs.js
+++ b/src/components/programs/Programs.js
@@ -18,6 +18,8 @@ const Content = () => {
           <div className="header-details">
             <h1>Open Source Programs</h1>
 
+            <p>Here you can find all the resources and details of Open Source Programs and event that are available across different countries.</p>
+
             <Link to="container" smooth={true} duration={1000}>
               <h4>Explore all</h4>
             </Link>

--- a/src/components/web-dev/Web-dev.js
+++ b/src/components/web-dev/Web-dev.js
@@ -26,6 +26,9 @@ const Content = () => {
         <div className="landing-page-header">
           <div className="header-details">
             <h1>Web Dev Tools</h1>
+
+            <p>A collection of all the tools that are required in web development made by the community to ease the process of web development like CSS Generators, Icons, Illustration, etc.</p>
+
             <Link to="container" smooth={true} duration={1000}>
               <h4>Explore all</h4>
             </Link>


### PR DESCRIPTION
Closes #26.

# Subheadings are added to each page under the title.

@swapnilsparsh suggested moving sub-headings to the right of the heading. Unfortunately, that won't be possible as the "Open Source Programs" heading is too long to accommodate that design.

![image](https://user-images.githubusercontent.com/21984964/135720359-726928dc-f9b7-4d1f-8083-22d20a36b95e.png)