### PR TITLE
[#69] Fixed the Program description not fitting inside card properly

### DIFF
--- a/src/components/programs/Programs.js
+++ b/src/components/programs/Programs.js
@@ -16,6 +16,11 @@ const Content = () => {
     ? Datas.filter((data) => data.head.toLowerCase().includes(searchTerm.toLowerCase()))
     : Datas;
 
+    const getStrippedAboutBasedOnHeaderLength = ({ head, about }) => {
+      const aboutMaxCharCount = head.length > 18 ? 45 : 75;
+      return about.length > aboutMaxCharCount ? `${about.slice(0, aboutMaxCharCount)}...` : about;
+    }
+
   return (
     <>
       <div className="container-landing">
@@ -57,7 +62,7 @@ const Content = () => {
                         <h3>{data.head}</h3>
                         <img src={data.image} alt={data.alt}></img>
                       </a>
-                      <p>{data.about}</p>
+                      <p>{getStrippedAboutBasedOnHeaderLength(data)}</p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This is an attempt to fix( issue #69 ) the open source program cards description to fit inside the card properly. This is done by limiting the characters count for 
- descriptions to fit in `2 lines` for headings coming in `2 lines`
- descriptions to fit in `3 lines` for headings coming in `1 line`

**NB:** _as I mentioned before this could fail in some cases rarely because the font we are using is not a `monospaced` one and the character counts are an average calculation based on the data currently in the page._

Attaching the screenshots of open source program cards before and after the fix

**Open source program cards before the fix**
<img width="913" alt="Screenshot 2021-10-10 at 8 18 12 PM" src="https://user-images.githubusercontent.com/56071561/136701331-a5ceb5cb-28b4-4c82-888c-6b57b18511ea.png">

**Open source program cards after the fix**
<img width="906" alt="Screenshot 2021-10-10 at 8 18 36 PM" src="https://user-images.githubusercontent.com/56071561/136701374-79c20038-8fe1-42f3-a6a1-2a3ccb06b10b.png">

Please suggest if you have any alternatives for the approach, we could discuss about it. Thank you :)