### PR TITLE
[GSSOC'23] BUG solved - Hide previous and next arrow when on first or last page

### DIFF
--- a/components/ReactPaginateComponent.js
+++ b/components/ReactPaginateComponent.js
@@ -5,11 +5,16 @@ export default function ReactPaginateComponent({
   pageCount,
   changePage,
   forcePage,
+  pageNumber,
 }) {
   return (
     <ReactPaginate
-      previousLabel={<i className="fa fa-chevron-left"></i>}
-      nextLabel={<i className="fa fa-chevron-right"></i>}
+    previousLabel={
+      pageNumber === 0 ? null : <i className="fa fa-chevron-left"></i>
+    }
+    nextLabel={
+      pageNumber === pageCount-1 ? null : <i className="fa fa-chevron-right"></i>
+    }
       pageCount={pageCount}
       onPageChange={changePage}
       containerClassName={"paginationBttns"}

--- a/pages/ambassador.js
+++ b/pages/ambassador.js
@@ -88,6 +88,7 @@ const Content = () => {
           )}
         </div>
         <ReactPaginateComponent
+          pageNumber={pageNumber}
           pageCount={pageCount}
           changePage={changePageNumber}
           forcePage={searchTerm !== "" ? filteredPageNumber : pageNumber}

--- a/pages/games.js
+++ b/pages/games.js
@@ -87,6 +87,7 @@ const Content = () => {
           )}
         </div>
         <ReactPaginateComponent
+          pageNumber={pageNumber}
           pageCount={pageCount}
           changePage={changePageNumber}
           forcePage={searchTerm !== "" ? filteredPageNumber : pageNumber}

--- a/pages/programs.js
+++ b/pages/programs.js
@@ -87,6 +87,7 @@ const Content = () => {
           )}
         </div>
         <ReactPaginateComponent
+          pageNumber={pageNumber}
           pageCount={pageCount}
           changePage={changePageNumber}
           forcePage={searchTerm !== "" ? filteredPageNumber : pageNumber}

--- a/pages/webdev.js
+++ b/pages/webdev.js
@@ -133,6 +133,7 @@ const Content = () => {
           )}
         </div>
         <ReactPaginateComponent
+          pageNumber={pageNumber}
           pageCount={pageCount}
           changePage={changePageNumber}
           forcePage={searchTerm !== "" ? filteredPageNumber : pageNumber}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1609,6 +1609,7 @@ hr {
 }
 .disabledLinkClassName {
   opacity: 1;
+  pointer-events: none;
 }
 .disabledLinkClassName:hover {
   cursor: default;


### PR DESCRIPTION
#202 Solved bug - Hide previous and next arrow when on first or last page 
![image](https://github.com/swapnilsparsh/DevEmpire/assets/72180614/eec4c3a5-2287-4715-b505-bad98a3b5e4b)
![image](https://github.com/swapnilsparsh/DevEmpire/assets/72180614/26fcfbd4-c2a6-4d70-9159-da332723999b)
