### PR TITLE
footer links fixed

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -11,6 +11,7 @@ import {
   Heading2
 } from "./FooterStyles";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 
 const ThemeToggle = dynamic(() => import("./ThemeToggle"), {
   ssr: false,
@@ -75,10 +76,18 @@ const Footer = () => {
         <div className="column2">
           <Column2>
             <Heading2>Explore</Heading2>
-            <FooterLink href="/ambassador">Ambasaddor</FooterLink>
-            <FooterLink href="/programs">Programs</FooterLink>
-            <FooterLink href="/webdev">WebDev</FooterLink>
-            <FooterLink href="/games">Games</FooterLink>
+            <Link href="/ambassador">
+            <FooterLink >Ambasaddor</FooterLink>
+            </Link>
+            <Link href="/programs">
+            <FooterLink>Programs</FooterLink>
+            </Link>
+            <Link href="/webdev">
+            <FooterLink >WebDev</FooterLink>
+            </Link>
+            <Link href="/games">
+            <FooterLink >Games</FooterLink>
+            </Link>
           </Column2>
         </div>
       </div>

--- a/components/FooterStyles.js
+++ b/components/FooterStyles.js
@@ -13,6 +13,7 @@ export const FooterLink = styled.a`
   margin-bottom: 20px;
   font-size: 18px;
   text-decoration: none;
+  cursor:pointer;
 
   &:hover {
     color: purple;


### PR DESCRIPTION
# Description

Added nextjs Links , that are wrapping styled footer links. 
Actually i've tried to use nextjs Link component inside StyledFooter (styled(Link) instead of styled.a), but there was some issue that those styles did not applied to <a> tags. 
Current solution is maybe not as good looking, but works fine. 

## Fixes #271 

## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [ ] All tests are passing