### PR TITLE
🛠️ Fixing Navbar Auto-Opening Issue on DevEmpire Mobile Website 📱"

### DIFF
--- a/components/navbar/Links.js
+++ b/components/navbar/Links.js
@@ -126,7 +126,7 @@ const Links = () => {
       <div
         className="navNarrow-container"
         onMouseLeave={() => {
-          setmenuopen(!menuopen);
+
         }}
       >
         <div className="navNarrow-Bar">


### PR DESCRIPTION
# Description

## Fixes #345

🛠️ This pull request addresses the problem of the Navbar automatically opening up when clicking on links like "Ambassador" or "Games" in the DevEmpire mobile website's header, as well as when clicking on page numbers. The changes implemented prevent the unintended Navbar behavior, providing a smoother user experience while navigating through the website on mobile devices. 📱

## Screenshots


https://github.com/swapnilsparsh/DevEmpire/assets/85815172/30055c30-aed7-4c7d-b6d9-ea788516dc35


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing