### PR TITLE
Fixed the website broken image in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## DevEmpire
-![DevEmpire](https://res.cloudinary.com/dxxeks4o5/image/upload/v1690128171/Meta_niqqe1.png)
+![DevEmpire](https://github.com/swapnilsparsh/DevEmpire/blob/master/public/assets/meta-img/Meta.webp)
 
 ## 📌 Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## DevEmpire
-![DevEmpire](https://github.com/swapnilsparsh/DevEmpire/blob/master/public/assets/meta-img/Meta.png)
+![DevEmpire](https://res.cloudinary.com/dxxeks4o5/image/upload/v1690128171/Meta_niqqe1.png)
 
 ## 📌 Introduction
 


### PR DESCRIPTION
# Description

-  In readme file we cannot use the github link for the images we have to upload the image in cloud then we have to use it in readme .
- I uploaded the image in cloudinary and the link in readme file so that it display properly

## Fixes #396

## Screenshots

<img width="960" alt="Screenshot 2023-07-23 214006" src="https://github.com/swapnilsparsh/DevEmpire/assets/101205226/a3acef95-754c-4e87-a97f-a935592a50e9">


## Checklist

<!-- Mark the completed tasks with [x] -->
- [ x] Tests have been added or updated to cover the changes
- [x ] Documentation has been updated to reflect the changes
- [x ] Code follows the established coding style guidelines
- [x ] All tests are passing